### PR TITLE
Add optional timeout for commands in the config file

### DIFF
--- a/src/execvars.c
+++ b/src/execvars.c
@@ -164,7 +164,7 @@ void main(int argc, char **argv)
     /* clear the execvars state object */
     memset( &state, 0, sizeof( state ) );
 
-    if( argc < 2 )
+    if( argc < 3 )
     {
         usage( argv[0] );
         exit( 1 );
@@ -455,10 +455,10 @@ static void usage( char *cmdname )
     if( cmdname != NULL )
     {
         fprintf(stderr,
-                "usage: %s [-v] [-h] "
-                " [-h] : display this help"
-                " [-v] : verbose output"
-                " -f <filename> : configuration file",
+                "usage: %s [-v] [-h] -f <filename>\n"
+                " [-h] : display this help\n"
+                " [-v] : verbose output\n"
+                " -f <filename> : configuration file\n",
                 cmdname );
     }
 }

--- a/src/execvars.c
+++ b/src/execvars.c
@@ -589,6 +589,7 @@ static int ExecuteCommand( char *cmd, int fd, int timeout_seconds )
                                 /* timeout occurred, kill the process */
                                 result = EINVAL;
                                 kill( pid, SIGKILL );
+                                syslog( LOG_ERR, "Timeout %d seconds exceeded for command %s\n", timeout_seconds, cmd );
                             }
                             else
                             {


### PR DESCRIPTION
This PR aims at fixing a problem when a command from the config file may stall, causing the whole process to stall. The PR introduces an optional command line parameter
```
[-t] : timeout in seconds (will create a new process for every exec call)
```
specifying a global timeout for every command that execvars needs to execute. If a timeout is reached, the subprocess is killed an empty response returned.

---

Tested with the following sample files:
Variable declaration `test_execvars.json`:
```
{
    "type":"vars",
    "version":"1.0",
    "description":"Diagnostic Vars",
    "modified":"31-Aug-2023",
    "vars":
    [
        {
            "name":"/sys/info/fs",
            "type":"str",
            "length": "8",
            "tags":"diag",
            "fmt":"%s",
            "value":"TBD",
            "shortname":"fsinfo",
            "description":"File System Info",
            "flags":"volatile"
        }
    ]
}
```
The config file `test_execvars.cfg`:
```
{
    "commands" : [
        { "var" : "/sys/info/fs",
          "exec" : "sleep 3; echo ; df -h" }
    ]
}
```
And the following commands to execute normally:
```
$ execvars -f test_execvars.cfg -t 5 &
$ getvar /sys/info/fs

Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3,2G  4,2M  3,2G   1% /run
...
```
While the following causes a timeout
```
$ execvars -f test_execvars.cfg -t 2 &
$ getvar /sys/info/fs

$
```
and a message in the system log
```
shondll@shondll-X1:~$ journalctl -f | grep execvars
дек 11 12:16:44 shondll-X1 execvars[1405602]: Timeout 2 seconds exceeded for command sleep 3; echo ; df -h
```